### PR TITLE
Use location endpoint

### DIFF
--- a/airthings/__init__.py
+++ b/airthings/__init__.py
@@ -50,8 +50,8 @@ class AirthingsDevice:
             response.get("data"),
             response.get("segment").get("isActive"),
             location_name,
-            device.get('productName'),
             device.get('deviceType'),
+            device.get('productName'),
         )
 
     @property

--- a/airthings/__init__.py
+++ b/airthings/__init__.py
@@ -16,6 +16,21 @@ TIMEOUT = 10
 
 
 @dataclass
+class AirthingsLocation:
+    """Airthings location."""
+    location_id: str
+    name: str
+
+    @classmethod
+    def init_from_response(cls, response):
+        """Class method."""
+        return cls(
+            response.get("id"),
+            response.get("name"),
+        )
+
+
+@dataclass
 class AirthingsDevice:
     """Airthings device."""
     device_id: str

--- a/airthings/__init__.py
+++ b/airthings/__init__.py
@@ -110,13 +110,16 @@ class Airthings:
             json_data = await response.json()
             if json_data is None:
                 continue
-            for device in json_data.get("devices"):
-                id = device.get('id')
-                res[id] = AirthingsDevice.init_from_response(
-                    device,
-                    location.name,
-                    self._devices.get(id)
-                )
+            if devices := json_data.get("devices"):
+                for device in devices:
+                    id = device.get('id')
+                    res[id] = AirthingsDevice.init_from_response(
+                        device,
+                        location.name,
+                        self._devices.get(id)
+                    )
+            else:
+                _LOGGER.debug("No devices in location '%s'", location.name)
         return res
 
     async def _request(self, url, json_data=None, retry=3):


### PR DESCRIPTION
To reduce the number of network requests, we can use the `location` endpoint.

Instead of fetching device list + iterating all devices (n+1), we can fetch locations+device list, then iterate the locations to fetch latest samples.

Nothing wrong with the current implementation, but this caused some users to experience 429 error (too many requests) if they had >10 devices. For users with 10 devices, this will now be:
* Fetch locations
* Fetch device list (need the device type / product name)
* Iterate through locations (for most users this is 1 or 2)

In total 3 requests, and when locations and devices are cached, this will be 1 request. Most users has only one location, but in some cases they might have a cabin, maybe an autogenerated "hidden" location etc. In my case on my account, I have 3 locations. In my case I'll go from 7 (+ device list) to 3 (+ locations and device list).

Some user could have _many_ locations without any devices, this can be solved by ignoring empty locations. To keep this simple for now this is not covered in this PR.

This PR also includes `product_name`. Then we can use this directly in Home Assistant:
```python
airthings_device.product_name,
```
instead of this:
```python
airthings_device.device_type.replace("_", " ").lower().title(),
```
https://github.com/home-assistant/core/blob/dev/homeassistant/components/airthings/sensor.py#L152

Also added the `location_name` which can be helpful for debugging if the user has multiple devices with more or less the same name, for example `kitchen` in your home + cabin. Not sure where to use it / present it to the user, but it's now available to be used.

Documentation:
https://developer.airthings.com/consumer-api-docs#tag/Locations

Will fix these issues:
https://github.com/home-assistant/core/issues/101666
https://github.com/Danielhiversen/pyAirthings/issues/4

<details><summary>Example</summary>

```
{'xxxxxxxxxx': AirthingsDevice(device_id='xxxxxxxxxx', name='Emilie', sensors={'battery': 54, 'co2': 569.0, 'humidity': 39.0, 'pressure': 998.5, 'radonShortTermAvg': 30.0, 'rssi': -42, 'temp': 21.9, 'time': 1697452315, 'voc': 46.0, 'relayDeviceType': 'hub'}, is_active=None, location_name='Home', device_type='Wave Plus', product_name='WAVE_PLUS'), 'xxxxxxxxxx': AirthingsDevice(device_id='xxxxxxxxxx', name='Basement Mini', sensors={'battery': 97, 'humidity': 79.0, 'mold': 3.0, 'temp': 14.5, 'time': 1697447439, 'voc': 75.0, 'relayDeviceType': 'hub'}, is_active=None, location_name='Home', device_type='Wave Mini', product_name='WAVE_MINI'), 'xxxxxxxxxx': AirthingsDevice(device_id='xxxxxxxxxx', name='Office', sensors={'battery': 83, 'co2': 572.0, 'humidity': 37.0, 'pressure': 998.4, 'radonShortTermAvg': 22.0, 'rssi': -51, 'temp': 22.7, 'time': 1697452384, 'voc': 46.0, 'relayDeviceType': 'hub'}, is_active=None, location_name='Home', device_type='Wave Plus', product_name='WAVE_PLUS'), 'xxxxxxxxxx': AirthingsDevice(device_id='xxxxxxxxxx', name='Basement Wave', sensors={'battery': 54, 'humidity': 81.0, 'radonShortTermAvg': 899.0, 'temp': 14.3, 'time': 1697433607, 'relayDeviceType': 'hub'}, is_active=None, location_name='Home', device_type='Wave', product_name='WAVE_GEN2'), 'xxxxxxxxxx': AirthingsDevice(device_id='xxxxxxxxxx', name='Bathroom', sensors={'battery': 31, 'humidity': 45.0, 'mold': 0.0, 'temp': 25.5, 'time': 1695641686, 'voc': 59.0, 'relayDeviceType': 'hub'}, is_active=None, location_name='Home', device_type='Wave Mini', product_name='WAVE_MINI'), 'xxxxxxxxxx': AirthingsDevice(device_id='xxxxxxxxxx', name='Living Room', sensors={'battery': 7, 'co2': 583.0, 'humidity': 34.0, 'pm1': 0.0, 'pm25': 0.0, 'pressure': 998.0, 'radonShortTermAvg': 24.0, 'temp': 23.1, 'time': 1697452327, 'voc': 46.0, 'relayDeviceType': 'hub'}, is_active=None, location_name='Home', device_type='View Plus', product_name='VIEW_PLUS'), 'xxxxxxxxxx': AirthingsDevice(device_id='xxxxxxxxxx', name='Kitchen', sensors={'battery': 73, 'co2': 561.0, 'humidity': 36.0, 'pm1': 0.0, 'pm25': 0.0, 'pressure': 998.3, 'radonShortTermAvg': 23.0, 'temp': 22.1, 'time': 1697451917, 'voc': 48.0, 'relayDeviceType': 'hub'}, is_active=None, location_name='Home', device_type='View Plus', product_name='VIEW_PLUS'), 'xxxxxxxxxx': AirthingsDevice(device_id='xxxxxxxxxx', name='Hub', sensors={}, is_active=None, location_name='-', device_type='Hub', product_name='HUB')}
```
</details>

Disclaimer: I work for Airthings. Discussed this problem with the cloud developers and this is the way to go. Less load on our cloud, and fewer 429 errors for the users.