### PR TITLE
Refetch locations

### DIFF
--- a/airthings/__init__.py
+++ b/airthings/__init__.py
@@ -83,15 +83,21 @@ class Airthings:
         self._access_token = None
         self._locations = []
         self._devices = {}
+    
+    async def _fetch_locations(self):
+        response = await self._request(API_URL + "locations")
+        json_data = await response.json()
+        self._locations = []
+        for location in json_data.get("locations"):
+            self._locations.append(AirthingsLocation.init_from_response(location))
 
     async def update_devices(self):
         """Update data."""
+        locations_fetched = False
+
         if not self._locations:
-            response = await self._request(API_URL + "locations")
-            json_data = await response.json()
-            self._locations = []
-            for location in json_data.get("locations"):
-                self._locations.append(AirthingsLocation.init_from_response(location))
+            await self._fetch_locations()
+            locations_fetched = True
         if not self._devices:
             response = await self._request(API_URL + "devices")
             json_data = await response.json()
@@ -112,6 +118,11 @@ class Airthings:
                 continue
             if devices := json_data.get("devices"):
                 for device in devices:
+                    if not isinstance(device, dict) or 'id' not in device:
+                        if not locations_fetched:
+                            _LOGGER.debug("Device has no id, fetching locations again")
+                            await self._fetch_locations()
+                            locations_fetched = True
                     id = device.get('id')
                     res[id] = AirthingsDevice.init_from_response(
                         device,

--- a/airthings/__init__.py
+++ b/airthings/__init__.py
@@ -83,7 +83,7 @@ class Airthings:
         self._access_token = None
         self._locations = []
         self._devices = {}
-    
+
     async def _fetch_locations(self):
         response = await self._request(API_URL + "locations")
         json_data = await response.json()


### PR DESCRIPTION
When a user adds a device, there will be a mismatch between the location and device endpoints, causing it to fail:

```
2025-05-30 23:10:53.515 ERROR (MainThread) [homeassistant.components.airthings] Unexpected error fetching airthings data
  File "/usr/src/homeassistant/homeassistant/components/airthings/__init__.py", line 38, in _update_method
    return await airthings.update_devices()  # type: ignore[no-any-return]
  File "/usr/local/lib/python3.13/site-packages/airthings/__init__.py", line 116, in update_devices
    res[id] = AirthingsDevice.init_from_response(
  File "/usr/local/lib/python3.13/site-packages/airthings/__init__.py", line 53, in init_from_response
```

Fetching locations again will fix it